### PR TITLE
Add writable tmp/log volumes to Helm chart

### DIFF
--- a/charts/openanonymiser/templates/deployment.yaml
+++ b/charts/openanonymiser/templates/deployment.yaml
@@ -22,6 +22,11 @@ spec:
       serviceAccountName: {{ include "openanonymiser.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}
+        - name: logs-volume
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -44,4 +49,9 @@ spec:
             - name: INTERNAL_ONLY
               value: {{ .Values.app.api.internalOnly | quote }}
             - name: STORAGE_CLEANUP_INTERVAL
-              value: {{ .Values.app.storage.cleanupInterval | quote }} 
+              value: {{ .Values.app.storage.cleanupInterval | quote }}
+          volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
+            - name: logs-volume
+              mountPath: /app/logs

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -18,6 +18,7 @@ docker run -d -p 8000:8080 --name presidio-nl presidio-nl
 - De API is nu bereikbaar op [http://localhost:8000/docs](http://localhost:8000/docs)
 - De container draait op de achtergrond (`-d`).
 - Poort 8080 in de container wordt gemapt naar poort 8000 op je machine.
+- Er worden `emptyDir` volumes gekoppeld aan `/tmp` en `/app/logs` zodat de container kan schrijven. Dit voorkomt fouten als `os error 30` bij een read-only root filesystem.
 
 ## Stoppen en verwijderen
 


### PR DESCRIPTION
## Summary
- mount `/tmp` and `/app/logs` using `emptyDir` volumes in Helm deployment
- document why these volumes are required in `docs/docker.md`

## Testing
- `ruff check .`
- `mypy .` *(fails: unused ignores and type errors)*
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6867d1afe260832bb3c4ce2ff03af1e2