### PR TITLE
Implement document workflows

### DIFF
--- a/src/api/routers/documents.py
+++ b/src/api/routers/documents.py
@@ -1,7 +1,18 @@
 import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Response, UploadFile, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
 from fastapi import File as FastAPIFile
 from fastapi.responses import FileResponse
 
@@ -15,6 +26,10 @@ from src.api.dtos import (
     DocumentDto,
     DocumentTagDto,
 )
+from src.api.services.text_analyzer import ModularTextAnalyzer
+from src.api.utils import pdf_xmp
+
+_DOCUMENT_STORE: dict[str, dict] = {}
 
 documents_router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -48,39 +63,69 @@ async def upload_document(
             message=f"Only files with the following extensions are supported: {', '.join(settings.SUPPORTED_UPLOAD_EXTENSIONS)}"
         )
 
-    # TODO: read file here and generate UUID
-    content = await file.read()
-    await file.close()
+    analyzer = ModularTextAnalyzer()
+    docs: list[DocumentDto] = []
 
-    # TODO: write file to disk (/temp/source/{file_id}.pdf)
+    for file in files:
+        content = await file.read()
+        await file.close()
 
-    # TODO: analyze file content for PII entities
+        file_id = uuid.uuid4().hex
+        source_dir = Path("temp/source")
+        source_dir.mkdir(parents=True, exist_ok=True)
+        source_path = source_dir / f"{file_id}.pdf"
+        with open(source_path, "wb") as f:
+            f.write(content)
 
-    # TODO: format tags
+        text = ""
+        try:
+            import fitz  # PyMuPDF
 
-    # TODO: format response
+            doc = fitz.open(str(source_path))
+            text = "\n".join(page.get_text() for page in doc)
+            doc.close()
+        except Exception:
+            text = ""
 
-    f = file
+        entities = analyzer.analyze_text(text) if text else []
+        unique: list[dict[str, str]] = []
+        seen = set()
+        for ent in entities:
+            key = (ent["entity_type"], ent["text"])
+            if key not in seen:
+                unique.append({"entity_type": ent["entity_type"], "text": ent["text"]})
+                seen.add(key)
 
-    return AddDocumentResponseSuccess(
-        files=[
-            DocumentDto(
-                id=f.id,
-                filename=f.filename,
-                blob_name=f.blob_name,
-                created_at=f.created_at,
-                tags=[DocumentTagDto(id=tag.id, name=tag.name) for tag in f.tags],
-                pii_entities=f.pii_entities,
-            )
-        ]
-    )
+        stored_tags = [DocumentTagDto(id=uuid.uuid4().hex, name=t) for t in tags or []]
+
+        doc_meta = DocumentDto(
+            id=file_id,
+            filename=file.filename or f"{file_id}.pdf",
+            content_type=file.content_type or "application/pdf",
+            uploaded_at=datetime.utcnow(),
+            tags=stored_tags,
+            pii_entities=unique,
+        )
+
+        _DOCUMENT_STORE[file_id] = {
+            "meta": doc_meta,
+            "source_path": str(source_path),
+            "anonymized_path": None,
+            "entities": entities,
+        }
+
+        docs.append(doc_meta)
+
+    return AddDocumentResponseSuccess(files=docs)
 
 
 @documents_router.get("/{file_id}/metadata", response_model=DocumentDto)
 async def get_document_metadata(file_id: str) -> DocumentDto:
     """Get metadata for a specific document. Same response as upload."""
-    # TODO: implement
-    return DocumentDto()
+    doc = _DOCUMENT_STORE.get(file_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return doc["meta"]
 
 
 @documents_router.post("/{file_id}/anonymize")
@@ -88,20 +133,76 @@ async def anonymize_document(
     file_id: str, request_body: DocumentAnonymizationRequest
 ) -> DocumentAnonymizationResponse:
     """Anonymize a specific document."""
-    pass
+    doc = _DOCUMENT_STORE.get(file_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    source_path = doc["source_path"]
+    analyzer = ModularTextAnalyzer()
+
+    entities = doc.get("entities")
+    if not entities:
+        text = ""
+        try:
+            import fitz
+
+            pdf_doc = fitz.open(source_path)
+            text = "\n".join(p.get_text() for p in pdf_doc)
+            pdf_doc.close()
+        except Exception:
+            text = ""
+        entities = analyzer.analyze_text(text) if text else []
+        doc["entities"] = entities
+
+    selected = [
+        e for e in entities if e["entity_type"] in request_body.pii_entities_to_anonymize
+    ]
+    mapping = {e["text"]: e["entity_type"].lower() for e in selected}
+
+    anonym_dir = Path("temp/anonymized")
+    anonym_dir.mkdir(parents=True, exist_ok=True)
+    out_path = anonym_dir / f"{file_id}.pdf"
+
+    start = time.perf_counter()
+    try:
+        key = (settings.CRYPTO_KEY or b"secret").decode()
+        pdf_xmp.anonymize_pdf(source_path, str(out_path), mapping, key)
+        status_text = "success"
+    except Exception as exc:  # pragma: no cover - depends on external libs
+        status_text = f"failed: {exc}"
+    end = time.perf_counter()
+
+    doc["anonymized_path"] = str(out_path)
+
+    return DocumentAnonymizationResponse(
+        id=file_id,
+        filename=doc["meta"].filename,
+        anonymized_at=datetime.utcnow(),
+        time_taken=int(end - start),
+        status=status_text,
+        pii_entities=selected,
+    )
 
 
 @documents_router.get("/{file_id}/download")
 async def download_document(
-    file_id: str, delete_from_server: bool = True
+    file_id: str, keep_on_server: bool = False
 ) -> FileResponse:
     """Download a specific document.
 
     Now we can use FastAPI's FileResponse to serve the file directly from disk;
     however in the future, we may use StreamingResponse to stream large files (from memory or disk) to the client.
     """
-    # TODO: find file by file_id, in /temp/ folder, read content and stream to client
-    confirmed_path = f"/temp/{file_id}.pdf"
-    confirmed_filename = f"{file_id}.pdf"
+    doc = _DOCUMENT_STORE.get(file_id)
+    if not doc or not doc.get("anonymized_path"):
+        raise HTTPException(status_code=404, detail="Document not anonymized")
 
-    return FileResponse(path=confirmed_path, filename=confirmed_filename)
+    path = Path(doc["anonymized_path"])
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    background = BackgroundTasks()
+    if not keep_on_server:
+        background.add_task(path.unlink)
+
+    return FileResponse(path=str(path), filename=path.name, background=background)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,38 @@
+import io
+
+import fitz  # PyMuPDF
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+client = TestClient(app)
+
+
+def create_test_pdf(text: str) -> bytes:
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    pdf_bytes = doc.write()
+    doc.close()
+    return pdf_bytes
+
+
+def test_full_document_flow():
+    pdf_content = create_test_pdf("My name is John Doe. Contact john@example.com")
+    files = {"files": ("test.pdf", io.BytesIO(pdf_content), "application/pdf")}
+
+    resp = client.post("/api/v1/documents/upload", files=files)
+    assert resp.status_code == 200
+    file_id = resp.json()["files"][0]["id"]
+
+    resp = client.get(f"/api/v1/documents/{file_id}/metadata")
+    assert resp.status_code == 200
+
+    body = {"pii_entities_to_anonymize": ["PERSON", "EMAIL"]}
+    resp = client.post(f"/api/v1/documents/{file_id}/anonymize", json=body)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "success"
+
+    resp = client.get(f"/api/v1/documents/{file_id}/download", params={"keep_on_server": True})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"


### PR DESCRIPTION
## Summary
- implement document upload, metadata, anonymize and download
- store files in temp folders and track metadata in-memory
- add integration test covering document workflow

## Testing
- `ruff check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6867e82ea9188322b3ae06b91387b0ff